### PR TITLE
fix grey buttons on webkit/Safari

### DIFF
--- a/css/agency.css
+++ b/css/agency.css
@@ -95,6 +95,7 @@ img::-moz-selection {
 .btn-primary {
   background-color: #118a04;
   border-color: #118a04;
+  -webkit-appearance: none;
 }
 
 .btn-primary:active, .btn-primary:focus, .btn-primary:hover {


### PR DESCRIPTION
AFAICT bootstrap.css causes the buttons on Safari to be grey, because it defines `-webkit-appearance: button` in the `button` class.

Overriding this in agency.css with `-webkit-appearance: none` seems to do the trick and make buttons appear as intended again. 

There might be more elegant ways to do this but I hope it helps clarify the issue.